### PR TITLE
Add forwardRef to all components

### DIFF
--- a/build.js
+++ b/build.js
@@ -64,18 +64,18 @@ const processRepo = () => {
         imports.push([path.join(name, outFileName), pascalName]);
 
         let processed = contents.trim().split("\n").join("\n    ");
-        processed = `<svg {...props} ${processed.substr(4)}`;
+        processed = `<svg {...props} ref={ref} ${processed.substr(4)}`;
 
         fs.writeFileSync(
           out,
           `
 import React from "react";
 
-export const ${pascalName} = (props: React.SVGProps<SVGSVGElement>) => {
+export const ${pascalName} = React.forwardRef<SVGSVGElement, React.SVGProps<SVGSVGElement>>((props, ref) => {
   return (
     ${processed}
   )
-}
+})
           `.trim() + "\n"
         );
       });


### PR DESCRIPTION
This PR adds `React.forwardRef` to all generated components, and I believe closes #2.

I tested this on one of my projects, and it seems to work.

+1 for the simple build process btw! 👍